### PR TITLE
fix: 更正秘密通道题库URL

### DIFF
--- a/leetcodeRating_greasyfork.user.js
+++ b/leetcodeRating_greasyfork.user.js
@@ -183,6 +183,7 @@
     const pbUrl = "https://leetcode.cn/problems/.*"
     const searchUrl = "https://leetcode.cn/search/.*"
     const studyUrl = "https://leetcode.cn/studyplan/.*"
+    const problemUrl = "https://leetcode.cn/problemset"
 
     // req相关url
     const lcnojgo = "https://leetcode.cn/graphql/noj-go/"
@@ -1967,7 +1968,7 @@ if (GM_getValue("switchperson")) {
     jQuery(document).ready(function ($) {
         $("#spig").mousedown(function (e) {
             if(e.which == 3){
-                showMessage(`秘密通道:<br/> <a href="${allUrl}" title="题库">题库</a>`,10000);
+                showMessage(`秘密通道:<br/> <a href="${problemUrl}" title="题库">题库</a>`,10000);
             }
         });
         $("#spig").bind("contextmenu", function(e) {


### PR DESCRIPTION
我更正了右键纸片人出现的题库超链接的url，可以直接跳转到题库了，之前会404
下图是之前点击跳转的效果
![image](https://github.com/user-attachments/assets/50e11696-4eda-456d-8ba5-9365726eff69)
