### PR TITLE
fix: restore problem page rating display and fix daily data refresh (v2.0.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 ./.vscode
 .DS_Store
 settings.json
+.claude/

--- a/leetcodeRating_greasyfork.user.js
+++ b/leetcodeRating_greasyfork.user.js
@@ -23,6 +23,7 @@
 // @require      https://gcore.jsdelivr.net/gh/andywang425/BLTH@4368883c643af57c07117e43785cd28adcb0cb3e/assets/js/library/layer.min.js
 // @resource css https://gcore.jsdelivr.net/gh/andywang425/BLTH@d25aa353c8c5b2d73d2217b1b43433a80100c61e/assets/css/layer.css
 // @grant        unsafeWindow
+// @noframes
 // @run-at       document-end
 // @note         2022-12-29 1.1.0 add english site support
 // @note         2022-12-29 1.1.1 fix when the dark mode is turned on, the prompt display is abnormal
@@ -38,7 +39,7 @@
   let t2rate = {}
   const version = "2.0.0"
   const DEBUG_MODE = false
-  
+
   const originalConsoleLog = console.log
   if (!DEBUG_MODE) {
     try {
@@ -52,45 +53,6 @@
     }
   }
 
-  // a timer manager for all pages
-  const TimerManager = {
-    timers: {
-      allProblems: null, // 题目列表页 contains all the problems
-      problem: null, // 单题页 the specific problem page
-      problemList: null, // 题单页 the problem list page
-    },
-
-    // 设置定时器 set timer
-    set(type, intervalId) {
-      this.clear(type)
-      this.timers[type] = intervalId
-      console.log(`[TimerManager] Set timer for ${type}: ${intervalId}`)
-    },
-
-    // 清除指定类型的定时器 clear the timer for the specific type
-    clear(type) {
-      if (this.timers[type]) {
-        clearInterval(this.timers[type])
-        console.log(
-          `[TimerManager] Cleared timer for ${type}: ${this.timers[type]}`
-        )
-        this.timers[type] = null
-      }
-    },
-
-    // 清除所有定时器 clear all timers
-    clearAll() {
-      Object.keys(this.timers).forEach((type) => {
-        this.clear(type)
-      })
-      console.log("[TimerManager] Cleared all timers")
-    },
-
-    // 获取定时器ID get the timer id
-    get(type) {
-      return this.timers[type]
-    },
-  }
   let preDate
   const allProblemsUrl = "https://leetcode.com/problemset" // the problems page, contains all problems
   const problemListUrl = "https://leetcode.com/problem-list" // the problem list page, such as "https://leetcode.com/problem-list/array/"
@@ -102,69 +64,6 @@
     const str = JSON.stringify(obj)
     return JSON.parse(str)
   }
-
-  // URL变化监听管理器 (已注释掉，改用纯定时器方式)
-  /*
-  const UrlChangeManager = {
-    isInitialized: false,
-    urlChangeHandler: null,
-    
-    // 初始化URL变化监听
-    init() {
-      if (this.isInitialized) return
-      this.isInitialized = true
-      
-      const oldPushState = history.pushState
-      const oldReplaceState = history.replaceState
-      
-      history.pushState = function pushState(...args) {
-        const res = oldPushState.apply(this, args)
-        window.dispatchEvent(new Event("urlchange"))
-        return res
-      }
-      
-      history.replaceState = function replaceState(...args) {
-        const res = oldReplaceState.apply(this, args)
-        window.dispatchEvent(new Event("urlchange"))
-        return res
-      }
-      
-      window.addEventListener("popstate", () => {
-        window.dispatchEvent(new Event("urlchange"))
-      })
-      
-      console.log("[UrlChangeManager] URL change detection initialized")
-    },
-    
-    // 设置URL变化处理器（确保只有一个）
-    setHandler(handler) {
-      // 移除旧的处理器
-      if (this.urlChangeHandler) {
-        window.removeEventListener("urlchange", this.urlChangeHandler)
-        console.log("[UrlChangeManager] Removed old urlchange handler")
-      }
-      
-      // 设置新的处理器
-      this.urlChangeHandler = handler
-      window.addEventListener("urlchange", this.urlChangeHandler)
-      console.log("[UrlChangeManager] Set new urlchange handler")
-    },
-    
-    // 清理处理器
-    clearHandler() {
-      if (this.urlChangeHandler) {
-        window.removeEventListener("urlchange", this.urlChangeHandler)
-        this.urlChangeHandler = null
-        console.log("[UrlChangeManager] Cleared urlchange handler")
-      }
-    }
-  }
-
-  // 监听URL变化事件（保持向后兼容）
-  function initUrlChange() {
-    return () => UrlChangeManager.init()
-  }
-  */
 
   // 获取时间
   function getCurrentDate(format) {
@@ -194,57 +93,51 @@
     return time
   }
 
-  function getProblemIndex(problem) {
-    // we can't use problem.id because for some problems, the id here is not the problem index, so we have to extract problem index from title text
-    const titleElement = problem.querySelector(".text-body .ellipsis")
-    if (!titleElement) return null
-    const titleText = titleElement.textContent || titleElement.innerText
-    const match = titleText.match(/^(\d+)\.\s/)
-    if (!match) return null
-    return match[1]
+  let lastProcessedProblemId
+
+  function replaceDifficultyWithRating(difficultyLabel) {
+    // 从难度标签向上遍历，找到包含题号的祖先行
+    let row = difficultyLabel.parentElement
+    while (row && !row.querySelector(".text-body .ellipsis")) {
+      row = row.parentElement
+      if (!row || row === document.body) return
+    }
+    const titleEl = row.querySelector(".text-body .ellipsis")
+    if (!titleEl) return
+    const match = (titleEl.textContent || "").match(/^(\d+)\.\s/)
+    if (!match) return
+    const problemIndex = match[1]
+    if (t2rate[problemIndex] != undefined) {
+      difficultyLabel.innerHTML = t2rate[problemIndex].Rating
+    }
   }
 
-  let lastProcessedListContent
-  let lastProcessedProblemId
-  // let lastProcessedUrl = ""  // URL变化检测相关
-  // let urlChangeTimeout = null  // URL变化检测相关
   function getAllProblemsData() {
     console.log(
-      "[LeetCodeRating] getAllProblemsData() polling - " +
+      "[LeetCodeRating] getAllProblemsData() - " +
         new Date().toLocaleTimeString()
     )
     try {
-      // find the element in devtools and click "copy JS path"
-      const problemList = document.querySelector(
-        "#__next > div.flex.min-h-screen.min-w-\\[360px\\].flex-col.text-label-1.dark\\:text-dark-label-1 > div.mx-auto.w-full.grow.lg\\:max-w-screen-xl.dark\\:bg-dark-layer-bg.lc-dsw-xl\\:max-w-none.flex.bg-white.p-0.md\\:max-w-none.md\\:p-0 > div > div.flex.w-full.flex-1.overflow-hidden > div > div.flex.flex-1.justify-center.overflow-hidden > div > div.mt-4.flex.flex-col.items-center.gap-4 > div.w-full.flex-1 > div"
+      const difficultyLabels = document.querySelectorAll(
+        'p[class*="text-sd-easy"], p[class*="text-sd-medium"], p[class*="text-sd-hard"]'
       )
-      // pb页面加载时直接返回
-      if (problemList == undefined) {
-        return
-      }
+      if (difficultyLabels.length === 0) return
 
-      // 防止过多的无效操作
-      if (
-        lastProcessedListContent != undefined &&
-        lastProcessedListContent == problemList.innerHTML
-      ) {
-        return
+      // 用已处理标记避免重复操作
+      let unprocessed = 0
+      for (const label of difficultyLabels) {
+        if (!label.dataset.lcRatingProcessed) unprocessed++
       }
+      if (unprocessed === 0) return
 
-      const problems = problemList.childNodes
-      for (const problem of problems) {
-        const problemIndex = getProblemIndex(problem)
-        if (problemIndex == null) continue
-
-        // get the difficulty display for the current problem
-        const problemDifficulty = problem.querySelector(
-          'p[class*="text-sd-easy"], p[class*="text-sd-medium"], p[class*="text-sd-hard"]'
-        )
-        if (problemDifficulty && t2rate[problemIndex] != undefined) {
-          problemDifficulty.innerHTML = t2rate[problemIndex].Rating
-        }
+      console.log(
+        `[LeetCodeRating] Found ${difficultyLabels.length} difficulty labels, ${unprocessed} unprocessed`
+      )
+      for (const label of difficultyLabels) {
+        if (label.dataset.lcRatingProcessed) continue
+        replaceDifficultyWithRating(label)
+        label.dataset.lcRatingProcessed = "1"
       }
-      lastProcessedListContent = deepclone(problemList.innerHTML)
     } catch (e) {
       return
     }
@@ -252,45 +145,16 @@
 
   function getProblemListData() {
     console.log(
-      "[LeetCodeRating] getProblemListData() polling - " +
+      "[LeetCodeRating] getProblemListData() - " +
         new Date().toLocaleTimeString()
     )
-    try {
-      const problemList = document.querySelector(
-        "#__next > div.flex.min-h-screen.min-w-\\[360px\\].flex-col.text-label-1.dark\\:text-dark-label-1 > div.mx-auto.w-full.grow.lg\\:max-w-screen-xl.dark\\:bg-dark-layer-bg.lc-dsw-xl\\:max-w-none.flex.bg-white.p-0.md\\:max-w-none.md\\:p-0 > div > div.lc-dsw-lg\\:flex-row.lc-dsw-lg\\:px-6.lc-dsw-lg\\:gap-8.lc-dsw-lg\\:justify-center.lc-dsw-xl\\:pl-10.flex.min-h-\\[600px\\].flex-1.flex-col.justify-start.px-4 > div.lc-dsw-lg\\:max-w-\\[699px\\].mt-6.flex.w-full.flex-col.items-center.gap-4 > div.lc-dsw-lg\\:max-w-\\[699px\\].w-full.flex-1 > div > div > div.absolute.left-0.top-0.h-full.w-full > div"
-      )
-
-      if (problemList == undefined) {
-        return
-      }
-
-      if (
-        lastProcessedListContent != undefined &&
-        lastProcessedListContent == problemList.innerHTML
-      ) {
-        return
-      }
-      const problems = problemList.childNodes
-      for (const problem of problems) {
-        const problemIndex = getProblemIndex(problem)
-        if (problemIndex == null) continue
-
-        const problemDifficulty = problem.querySelector(
-          'p[class*="text-sd-easy"], p[class*="text-sd-medium"], p[class*="text-sd-hard"]'
-        )
-        if (problemDifficulty && t2rate[problemIndex] != undefined) {
-          problemDifficulty.innerHTML = t2rate[problemIndex].Rating
-        }
-      }
-      lastProcessedListContent = deepclone(problemList.lastChild.innerHTML)
-    } catch (e) {
-      return
-    }
+    // problem-list 页面与 problemset 页面使用相同的难度标签结构
+    getAllProblemsData()
   }
 
   function getProblemData() {
     console.log(
-      "[LeetCodeRating] getProblemData() polling - " +
+      "[LeetCodeRating] getProblemData() - " +
         new Date().toLocaleTimeString()
     )
     try {
@@ -390,7 +254,7 @@
           // 保留唯一标识
           t2rate = {}
           const dataStr = res.response
-          const json = eval(dataStr)
+          const json = JSON.parse(dataStr)
           console.log(`[Data Init] Parsed ${json.length} problem records`)
 
           for (const element of json) {
@@ -409,6 +273,8 @@
           preDate = now
           GM_setValue("preDate", preDate)
           GM_setValue("t2ratedb", JSON.stringify(t2rate))
+          // 数据加载完成后立即尝试处理当前页面
+          tryProcess()
         } else {
           console.log(`[Data Init] Failed to fetch data, status: ${res.status}`)
         }
@@ -420,239 +286,83 @@
     })
   }
 
-  function startTimers(url, timeout) {
-    console.log(`[startTimers] Starting with URL: ${url}, timeout: ${timeout}`)
+  // ==================== 页面处理调度 ====================
 
-    // 清理所有定时器
-    TimerManager.clearAll()
-
-    // 根据URL匹配对应的页面类型和函数
-    const pageConfig = {
-      allProblems: {
-        url: allProblemsUrl,
-        func: getAllProblemsData,
-        name: "getAllProblemsData()",
-      },
-      problem: {
-        url: problemUrl,
-        func: getProblemData,
-        name: "getProblemData()",
-      },
-      problemList: {
-        url: problemListUrl,
-        func: getProblemListData,
-        name: "getProblemListData()",
-      },
-    }
-
-    console.log(`[startTimers] Page config:`, pageConfig)
-    console.log(
-      `[startTimers] URL patterns - allProblems: ${allProblemsUrl}, problem: ${problemUrl}, problemList: ${problemListUrl}`
-    )
-
-    // 找到匹配的页面类型
-    let currentPageType = null
-    for (const [type, config] of Object.entries(pageConfig)) {
-      console.log(
-        `[startTimers] Checking if ${url} starts with ${
-          config.url
-        }: ${url.startsWith(config.url)}`
-      )
-      if (url.startsWith(config.url)) {
-        currentPageType = type
-        console.log(`[startTimers] Matched page type: ${currentPageType}`)
-        break
-      }
-    }
-
-    if (!currentPageType) {
-      console.log(`[startTimers] No matching page type found for URL: ${url}`)
-      return
-    }
-
-    const config = pageConfig[currentPageType]
-    console.log(`[startTimers] Using config for ${currentPageType}:`, config)
-
-    // 立即执行一次
-    console.log(`[startTimers] Starting immediate execution for ${config.name}`)
-    config.func()
-
-    // 启动定时器
-    console.log(
-      `[startTimers] Starting timer for ${currentPageType} with ${timeout}ms interval`
-    )
-    const timerId = setInterval(config.func, timeout)
-    TimerManager.set(currentPageType, timerId)
-
-    console.log(
-      `[startTimers] Setup complete for page type: ${currentPageType}`
-    )
+  // 根据当前 URL 判断页面类型
+  function getPageType() {
+    const url = location.href
+    // 注意：/problemset 以 /problems 开头，必须先匹配 problemset 再匹配 problems
+    if (url.startsWith(allProblemsUrl)) return "allProblems"
+    if (url.startsWith(problemListUrl)) return "problemList"
+    if (url.startsWith(problemUrl)) return "problem"
+    return null
   }
 
-  // 原版的 clearAndStart 函数 (已注释掉，改用 startTimers)
-  /*
-  function clearAndStart(url, timeout, isAddEvent) {
-    console.log(
-      `[clearAndStart] Starting with URL: ${url}, timeout: ${timeout}`
-    )
+  const pageFuncs = {
+    allProblems: getAllProblemsData,
+    problem: getProblemData,
+    problemList: getProblemListData,
+  }
 
-    // 清理所有定时器
-    TimerManager.clearAll()
-
-    // 根据URL匹配对应的页面类型和函数
-    const pageConfig = {
-      allProblems: {
-        url: allProblemsUrl,
-        func: getAllProblemsData,
-        name: "getAllProblemsData()",
-      },
-      problem: {
-        url: problemUrl,
-        func: getProblemData,
-        name: "getProblemData()",
-      },
-      problemList: {
-        url: problemListUrl,
-        func: getProblemListData,
-        name: "getProblemListData()",
-      },
-    }
-
-    console.log(`[clearAndStart] Page config:`, pageConfig)
-    console.log(
-      `[clearAndStart] URL patterns - allProblems: ${allProblemsUrl}, problem: ${problemUrl}, problemList: ${problemListUrl}`
-    )
-
-    // 找到匹配的页面类型
-    let currentPageType = null
-    for (const [type, config] of Object.entries(pageConfig)) {
-      console.log(
-        `[clearAndStart] Checking if ${url} starts with ${
-          config.url
-        }: ${url.startsWith(config.url)}`
-      )
-      if (url.startsWith(config.url)) {
-        currentPageType = type
-        console.log(`[clearAndStart] Matched page type: ${currentPageType}`)
-        break
-      }
-    }
-
-    if (!currentPageType) {
-      console.log(`[clearAndStart] No matching page type found for URL: ${url}`)
-    }
-
-    if (currentPageType) {
-      // 智能重试机制：立即执行，如果失败则短暂延迟后重试
-      const executeWithRetry = (func, funcName, maxRetries = 3) => {
-        let retryCount = 0
-        const tryExecute = () => {
-          console.log(
-            `[LeetCodeRating] Immediate execution for URL change: ${funcName} (attempt ${
-              retryCount + 1
-            })`
-          )
-
-          // 记录执行前的状态
-          const beforeState = {
-            lastProcessedProblemId: lastProcessedProblemId,
-            lastProcessedListContent: lastProcessedListContent,
-          }
-          func()
-          const afterState = {
-            lastProcessedProblemId: lastProcessedProblemId,
-            lastProcessedListContent: lastProcessedListContent,
-          }
-
-          // 检查是否成功执行（状态有变化）
-          const hasChanges =
-            JSON.stringify(beforeState) !== JSON.stringify(afterState)
-
-          if (!hasChanges && retryCount < maxRetries) {
-            retryCount++
-            console.log(
-              `[LeetCodeRating] ${funcName} - No changes detected, retrying in ${
-                200 * retryCount
-              }ms...`
-            )
-            setTimeout(tryExecute, 200 * retryCount) // 递增延迟: 200ms, 400ms, 600ms
-          } else if (hasChanges) {
-            console.log(
-              `[LeetCodeRating] ${funcName} - Successfully executed with changes`
-            )
-          } else {
-            console.log(
-              `[LeetCodeRating] ${funcName} - Max retries reached, will rely on timer`
-            )
-          }
-        }
-        tryExecute()
-      }
-
-      const config = pageConfig[currentPageType]
-      console.log(
-        `[clearAndStart] Using config for ${currentPageType}:`,
-        config
-      )
-
-      // 立即执行
-      console.log(
-        `[clearAndStart] Starting immediate execution for ${config.name}`
-      )
-      executeWithRetry(config.func, config.name)
-
-      // 启动定时器
-      console.log(
-        `[clearAndStart] Starting timer for ${currentPageType} with ${timeout}ms interval`
-      )
-      const timerId = setInterval(config.func, timeout)
-      TimerManager.set(currentPageType, timerId)
-
-      console.log(
-        `[clearAndStart] Setup complete for page type: ${currentPageType}`
-      )
-    } else {
-      console.log(`[clearAndStart] No page type matched, no timers started`)
-    }
-
-    // 添加URL变化监听 (已注释掉，改用纯定时器方式)
-    if (isAddEvent) {
-      const urlChangeHandler = () => {
-        console.log("urlchange event happened")
-        const newUrl = location.href
-        
-        // 防抖处理：如果URL没有变化，忽略此次事件
-        if (newUrl === lastProcessedUrl) {
-          console.log("[UrlChangeManager] URL unchanged, ignoring event")
-          return
-        }
-        
-        // 清除之前的延时器
-        if (urlChangeTimeout) {
-          clearTimeout(urlChangeTimeout)
-        }
-        
-        // 延时执行，防止频繁触发
-        urlChangeTimeout = setTimeout(() => {
-          console.log(`[UrlChangeManager] Processing URL change: ${lastProcessedUrl} -> ${newUrl}`)
-          lastProcessedUrl = newUrl
-          clearAndStart(newUrl, 2000, false)
-          urlChangeTimeout = null
-        }, 100) // 100ms防抖延时
-      }
-      UrlChangeManager.setHandler(urlChangeHandler)
+  function tryProcess() {
+    const pageType = getPageType()
+    if (pageType && pageFuncs[pageType]) {
+      pageFuncs[pageType]()
     }
   }
-  */
 
-  [...document.querySelectorAll("*")].forEach((item) => {
+  // ==================== URL 变化检测 ====================
+  // Monkey-patch history.pushState / replaceState 以检测 SPA 导航
+
+  let lastUrl = location.href
+  const origPushState = history.pushState
+  const origReplaceState = history.replaceState
+
+  function onUrlChange() {
+    const newUrl = location.href
+    if (newUrl !== lastUrl) {
+      console.log(`[UrlChange] ${lastUrl} -> ${newUrl}`)
+      lastUrl = newUrl
+      // 重置缓存，确保新页面内容会被处理
+      document.querySelectorAll('[data-lc-rating-processed]').forEach(el => {
+        delete el.dataset.lcRatingProcessed
+      })
+      lastProcessedProblemId = undefined
+      tryProcess()
+    }
+  }
+
+  history.pushState = function (...args) {
+    const result = origPushState.apply(this, args)
+    onUrlChange()
+    return result
+  }
+
+  history.replaceState = function (...args) {
+    const result = origReplaceState.apply(this, args)
+    onUrlChange()
+    return result
+  }
+
+  window.addEventListener("popstate", onUrlChange)
+
+  // ==================== MutationObserver ====================
+  // 监听 DOM 变化，debounce 后处理（处理 URL 变化后 React 异步渲染的情况）
+
+  let debounceTimer = null
+  const observer = new MutationObserver(() => {
+    if (debounceTimer) clearTimeout(debounceTimer)
+    debounceTimer = setTimeout(tryProcess, 300)
+  })
+  observer.observe(document.body, { childList: true, subtree: true })
+
+  // ==================== 其他初始化 ====================
+
+  ;[...document.querySelectorAll("*")].forEach((item) => {
     item.oncopy = function (e) {
       e.stopPropagation()
     }
   })
-
-  // 初始化URL变化监听 (已注释掉，改用纯定时器方式)
-  // initUrlChange()()
 
   // 版本更新机制 (仅在主页检查)
   if (window.location.href.startsWith(allProblemsUrl)) {
@@ -711,12 +421,11 @@
     })
   }
 
-  // 启动主程序，使用2000ms间隔
+  // 初始处理当前页面
   console.log(`[Script Init] Starting LeetCodeRating script v${version}`)
   console.log(`[Script Init] Current URL: ${location.href}`)
   console.log(
     `[Script Init] t2rate data available: ${Object.keys(t2rate).length} entries`
   )
-
-  startTimers(location.href, 2000) // 2秒间隔
+  tryProcess()
 })()

--- a/leetcodeRating_greasyfork.user.js
+++ b/leetcodeRating_greasyfork.user.js
@@ -42,7 +42,9 @@
   const DEBUG_MODE = false
 
   if (!DEBUG_MODE) {
-    console.log = () => {}
+    try {
+      console.log = () => {}
+    } catch (e) {}
   }
 
   let preDate
@@ -58,16 +60,18 @@
     let row = difficultyLabel.parentElement
     while (row && !row.querySelector(".text-body .ellipsis")) {
       row = row.parentElement
-      if (!row || row === document.body) return
+      if (!row || row === document.body) return false
     }
     const titleEl = row.querySelector(".text-body .ellipsis")
-    if (!titleEl) return
+    if (!titleEl) return false
     const match = (titleEl.textContent || "").match(/^(\d+)\.\s/)
-    if (!match) return
+    if (!match) return false
     const problemIndex = match[1]
     if (t2rate[problemIndex] !== undefined) {
       difficultyLabel.textContent = t2rate[problemIndex].Rating
+      return true
     }
+    return false
   }
 
   function getAllProblemsData() {
@@ -93,8 +97,9 @@
       )
       for (const label of difficultyLabels) {
         if (label.dataset.lcRatingProcessed) continue
-        replaceDifficultyWithRating(label)
-        label.dataset.lcRatingProcessed = "1"
+        if (replaceDifficultyWithRating(label)) {
+          label.dataset.lcRatingProcessed = "1"
+        }
       }
     } catch (e) {
       console.error("[LeetCodeRating] getAllProblemsData error:", e)
@@ -192,18 +197,23 @@
         "Content-Type": "application/x-www-form-urlencoded",
       },
       onload: function (res) {
-        if (res.status === 200) {
-          console.log(`[Data Init] Successfully fetched data from server`)
-          // 保留唯一标识
-          t2rate = {}
+        if (res.status !== 200) {
+          console.log(`[Data Init] Failed to fetch data, status: ${res.status}`)
+          return
+        }
+        console.log(`[Data Init] Successfully fetched data from server`)
+        try {
           const dataStr = res.response
           const json = JSON.parse(dataStr)
           console.log(`[Data Init] Parsed ${json.length} problem records`)
 
+          // 暂存到 newRate，解析或处理失败时不破坏已有缓存
+          const newRate = {}
           for (const element of json) {
-            t2rate[element.ID] = element
-            t2rate[element.ID].Rating = Math.round(parseFloat(element.Rating))
+            newRate[element.ID] = element
+            newRate[element.ID].Rating = Math.round(parseFloat(element.Rating))
           }
+          t2rate = newRate
           console.log(
             `[Data Init] Processed t2rate, final keys count: ${
               Object.keys(t2rate).length
@@ -219,8 +229,12 @@
             delete el.dataset.lcRatingProcessed
           })
           tryProcess()
-        } else {
-          console.log(`[Data Init] Failed to fetch data, status: ${res.status}`)
+        } catch (e) {
+          console.error("[Data Init] Failed to parse/process data:", e)
+          console.error(
+            "[Data Init] Response snippet:",
+            (res.response || "").slice(0, 200)
+          )
         }
       },
       onerror: function (err) {

--- a/leetcodeRating_greasyfork.user.js
+++ b/leetcodeRating_greasyfork.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         LeetCodeRating｜English
 // @namespace    https://github.com/zhang-wangz
-// @version      2.0.0
+// @version      2.0.1
 // @license      MIT
 // @description  LeetCodeRating The score of the weekly competition is displayed, and currently supports the tag page, question bank page, problem_list page and question page
 // @author       小东是个阳光蛋(Leetcode Nickname of chinese site
@@ -32,12 +32,13 @@
 // @note         2023-09-20 1.1.4 fix the error that scores are not displayed properly due to ui changes in problem page
 // @note         2023-12-14 1.1.5 fix the error that scores are not displayed properly due to ui changes in problem set page
 // @note         2025-08-21 2.0.0 refactor the plugin, change the refresh and update logic
+// @note         2026-04-15 2.0.1 fix problem page rating display after LeetCode UI update; fix rating not shown on first install or daily first data fetch
 // ==/UserScript==
 
 (function () {
   "use strict"
   let t2rate = {}
-  const version = "2.0.0"
+  const version = "2.0.1"
   const DEBUG_MODE = false
 
   if (!DEBUG_MODE) {

--- a/leetcodeRating_greasyfork.user.js
+++ b/leetcodeRating_greasyfork.user.js
@@ -65,7 +65,7 @@
     if (!match) return
     const problemIndex = match[1]
     if (t2rate[problemIndex] !== undefined) {
-      difficultyLabel.innerHTML = t2rate[problemIndex].Rating
+      difficultyLabel.textContent = t2rate[problemIndex].Rating
     }
   }
 
@@ -128,7 +128,6 @@
       }
 
       if (problemIndex == null) {
-        lastProcessedProblemId = "unknown"
         return
       }
 
@@ -145,15 +144,15 @@
         console.log(
           `[LeetCodeRating] Found rating for problem ${problemIndex}: ${t2rate[problemIndex].Rating}`
         )
-        colorSpan.innerHTML = t2rate[problemIndex].Rating
+        colorSpan.textContent = t2rate[problemIndex].Rating
       } else {
         console.log(
           `[LeetCodeRating] No rating found for problem ${problemIndex}, restoring original difficulty`
         )
         const classList = colorSpan.getAttribute("class") || ""
-        if (classList.includes("text-difficulty-easy")) colorSpan.innerHTML = "Easy"
-        else if (classList.includes("text-difficulty-medium")) colorSpan.innerHTML = "Medium"
-        else if (classList.includes("text-difficulty-hard")) colorSpan.innerHTML = "Hard"
+        if (classList.includes("text-difficulty-easy")) colorSpan.textContent = "Easy"
+        else if (classList.includes("text-difficulty-medium")) colorSpan.textContent = "Medium"
+        else if (classList.includes("text-difficulty-hard")) colorSpan.textContent = "Hard"
       }
 
       lastProcessedProblemId = problemIndex
@@ -213,7 +212,11 @@
           GM_setValue("preDate", preDate)
           GM_setValue("t2ratedb", JSON.stringify(t2rate))
           GM_setValue("t2rateInitialized", "1")
-          // 数据加载完成后立即尝试处理当前页面
+          // 重置状态，确保当前页面用新数据重新处理
+          lastProcessedProblemId = undefined
+          document.querySelectorAll('[data-lc-rating-processed]').forEach(el => {
+            delete el.dataset.lcRatingProcessed
+          })
           tryProcess()
         } else {
           console.log(`[Data Init] Failed to fetch data, status: ${res.status}`)
@@ -296,11 +299,7 @@
 
   // ==================== 其他初始化 ====================
 
-  ;[...document.querySelectorAll("*")].forEach((item) => {
-    item.oncopy = function (e) {
-      e.stopPropagation()
-    }
-  })
+  document.addEventListener('copy', e => e.stopPropagation(), true)
 
   // 版本更新机制 (仅在主页检查)
   if (window.location.href.startsWith(allProblemsUrl)) {

--- a/leetcodeRating_greasyfork.user.js
+++ b/leetcodeRating_greasyfork.user.js
@@ -60,18 +60,16 @@
     let row = difficultyLabel.parentElement
     while (row && !row.querySelector(".text-body .ellipsis")) {
       row = row.parentElement
-      if (!row || row === document.body) return false
+      if (!row || row === document.body) return
     }
     const titleEl = row.querySelector(".text-body .ellipsis")
-    if (!titleEl) return false
+    if (!titleEl) return
     const match = (titleEl.textContent || "").match(/^(\d+)\.\s/)
-    if (!match) return false
+    if (!match) return
     const problemIndex = match[1]
     if (t2rate[problemIndex] !== undefined) {
       difficultyLabel.textContent = t2rate[problemIndex].Rating
-      return true
     }
-    return false
   }
 
   function getAllProblemsData() {
@@ -97,9 +95,8 @@
       )
       for (const label of difficultyLabels) {
         if (label.dataset.lcRatingProcessed) continue
-        if (replaceDifficultyWithRating(label)) {
-          label.dataset.lcRatingProcessed = "1"
-        }
+        replaceDifficultyWithRating(label)
+        label.dataset.lcRatingProcessed = "1"
       }
     } catch (e) {
       console.error("[LeetCodeRating] getAllProblemsData error:", e)

--- a/leetcodeRating_greasyfork.user.js
+++ b/leetcodeRating_greasyfork.user.js
@@ -56,7 +56,7 @@
   let preDate
   const allProblemsUrl = "https://leetcode.com/problemset" // the problems page, contains all problems
   const problemListUrl = "https://leetcode.com/problem-list" // the problem list page, such as "https://leetcode.com/problem-list/array/"
-  const problemUrl = "https://leetcode.com/problems" // the specific problem page, such as "https://leetcode.com/problems/two-sum/description/"
+  const problemUrl = "https://leetcode.com/problems/" // the specific problem page, such as "https://leetcode.com/problems/two-sum/description/"
   GM_addStyle(GM_getResourceText("css"))
 
   // 获取时间
@@ -133,6 +133,7 @@
         label.dataset.lcRatingProcessed = "1"
       }
     } catch (e) {
+      console.error("[LeetCodeRating] getAllProblemsData error:", e)
       return
     }
   }
@@ -194,6 +195,7 @@
 
       lastProcessedProblemId = problemIndex
     } catch (e) {
+      console.error("[LeetCodeRating] getProblemData error:", e)
       return
     }
   }
@@ -209,13 +211,13 @@
   preDate = GM_getValue("preDate", "")
   const now = getCurrentDate(1)
 
+  const t2rateInitialized = GM_getValue("t2rateInitialized", "")
+
   console.log(
-    `[Data Init] preDate: ${preDate}, now: ${now}, tagVersion exists: ${
-      t2rate.tagVersion != undefined
-    }`
+    `[Data Init] preDate: ${preDate}, now: ${now}, initialized: ${t2rateInitialized !== ""}`
   )
 
-  if (t2rate.tagVersion == undefined || preDate == "" || preDate != now) {
+  if (t2rateInitialized === "" || preDate === "" || preDate !== now) {
     console.log(`[Data Init] Need to fetch new data from server`)
 
     GM_xmlhttpRequest({
@@ -242,7 +244,6 @@
               Number.parseFloat(element.Rating) + 0.5
             )
           }
-          t2rate.tagVersion = {}
           console.log(
             `[Data Init] Processed t2rate, final keys count: ${
               Object.keys(t2rate).length
@@ -252,6 +253,7 @@
           preDate = now
           GM_setValue("preDate", preDate)
           GM_setValue("t2ratedb", JSON.stringify(t2rate))
+          GM_setValue("t2rateInitialized", "1")
           // 数据加载完成后立即尝试处理当前页面
           tryProcess()
         } else {
@@ -270,7 +272,6 @@
   // 根据当前 URL 判断页面类型
   function getPageType() {
     const url = location.href
-    // 注意：/problemset 以 /problems 开头，必须先匹配 problemset 再匹配 problems
     if (url.startsWith(allProblemsUrl)) return "allProblems"
     if (url.startsWith(problemListUrl)) return "problemList"
     if (url.startsWith(problemUrl)) return "problem"

--- a/leetcodeRating_greasyfork.user.js
+++ b/leetcodeRating_greasyfork.user.js
@@ -40,17 +40,8 @@
   const version = "2.0.0"
   const DEBUG_MODE = false
 
-  const originalConsoleLog = console.log
   if (!DEBUG_MODE) {
-    try {
-      console.log = function(...args) {
-      }
-    } catch (e) {
-      window.console = Object.assign({}, console, {
-        log: function(...args) {
-        }
-      })
-    }
+    console.log = () => {}
   }
 
   let preDate
@@ -58,34 +49,6 @@
   const problemListUrl = "https://leetcode.com/problem-list" // the problem list page, such as "https://leetcode.com/problem-list/array/"
   const problemUrl = "https://leetcode.com/problems/" // the specific problem page, such as "https://leetcode.com/problems/two-sum/description/"
   GM_addStyle(GM_getResourceText("css"))
-
-  // 获取时间
-  function getCurrentDate(format) {
-    const now = new Date()
-    const year = now.getFullYear() //得到年份
-    let month = now.getMonth() //得到月份
-    let date = now.getDate() //得到日期
-    let hour = now.getHours() //得到小时
-    let minu = now.getMinutes() //得到分钟
-    let sec = now.getSeconds() //得到秒
-    month = month + 1
-    if (month < 10) month = "0" + month
-    if (date < 10) date = "0" + date
-    if (hour < 10) hour = "0" + hour
-    if (minu < 10) minu = "0" + minu
-    if (sec < 10) sec = "0" + sec
-    let time = ""
-    // 精确到天
-    if (format == 1) {
-      time = year + "年" + month + "月" + date + "日"
-    }
-    // 精确到分
-    else if (format == 2) {
-      time =
-        year + "-" + month + "-" + date + " " + hour + ":" + minu + ":" + sec
-    }
-    return time
-  }
 
   let lastProcessedProblemId
 
@@ -101,7 +64,7 @@
     const match = (titleEl.textContent || "").match(/^(\d+)\.\s/)
     if (!match) return
     const problemIndex = match[1]
-    if (t2rate[problemIndex] != undefined) {
+    if (t2rate[problemIndex] !== undefined) {
       difficultyLabel.innerHTML = t2rate[problemIndex].Rating
     }
   }
@@ -169,7 +132,7 @@
         return
       }
 
-      if (lastProcessedProblemId == problemIndex) {
+      if (lastProcessedProblemId === problemIndex) {
         return
       }
 
@@ -178,7 +141,7 @@
       )
       if (!colorSpan) return
 
-      if (t2rate[problemIndex] != undefined) {
+      if (t2rate[problemIndex] !== undefined) {
         console.log(
           `[LeetCodeRating] Found rating for problem ${problemIndex}: ${t2rate[problemIndex].Rating}`
         )
@@ -207,9 +170,8 @@
     }`
   )
 
-  //   latestpb = JSON.parse(GM_getValue("latestpb", "{}").toString())
   preDate = GM_getValue("preDate", "")
-  const now = getCurrentDate(1)
+  const now = new Date().toISOString().slice(0, 10)
 
   const t2rateInitialized = GM_getValue("t2rateInitialized", "")
 
@@ -217,7 +179,7 @@
     `[Data Init] preDate: ${preDate}, now: ${now}, initialized: ${t2rateInitialized !== ""}`
   )
 
-  if (t2rateInitialized === "" || preDate === "" || preDate !== now) {
+  if (t2rateInitialized === "" || preDate !== now) {
     console.log(`[Data Init] Need to fetch new data from server`)
 
     GM_xmlhttpRequest({
@@ -240,16 +202,13 @@
 
           for (const element of json) {
             t2rate[element.ID] = element
-            t2rate[element.ID].Rating = Number.parseInt(
-              Number.parseFloat(element.Rating) + 0.5
-            )
+            t2rate[element.ID].Rating = Math.round(parseFloat(element.Rating))
           }
           console.log(
             `[Data Init] Processed t2rate, final keys count: ${
               Object.keys(t2rate).length
             }`
           )
-          console.log("everyday getdate once...")
           preDate = now
           GM_setValue("preDate", preDate)
           GM_setValue("t2ratedb", JSON.stringify(t2rate))
@@ -261,8 +220,7 @@
         }
       },
       onerror: function (err) {
-        console.log("error")
-        console.log(err)
+        console.error("[Data Init] Failed to fetch data:", err)
       },
     })
   }
@@ -361,15 +319,15 @@
           const dataStr = res.response
           const json = JSON.parse(dataStr)
           const v = json.version
-          const upcontent = json.content
-          if (v != version) {
+          const updateContent = json.content
+          if (v !== version) {
             layer.open({
               content:
                 '<div style="color:#000; padding: 8px;">' +
                 '<p><strong>LeetCodeRating</strong> has a new version!</p>' +
                 '<p><strong>Update content:</strong></p>' +
                 '<div style="background: #f5f5f5; padding: 8px; border-radius: 4px; margin: 8px 0;">' +
-                upcontent +
+                updateContent +
                 '</div>' +
                 '</div>',
               btn: ['Install Update', 'Later'],
@@ -395,8 +353,7 @@
         }
       },
       onerror: function (err) {
-        console.log("error")
-        console.log(err)
+        console.error("[Version Check] Failed to fetch version:", err)
       },
     })
   }

--- a/leetcodeRating_greasyfork.user.js
+++ b/leetcodeRating_greasyfork.user.js
@@ -59,12 +59,6 @@
   const problemUrl = "https://leetcode.com/problems" // the specific problem page, such as "https://leetcode.com/problems/two-sum/description/"
   GM_addStyle(GM_getResourceText("css"))
 
-  // 深拷贝 deep clone
-  function deepclone(obj) {
-    const str = JSON.stringify(obj)
-    return JSON.parse(str)
-  }
-
   // 获取时间
   function getCurrentDate(format) {
     const now = new Date()
@@ -158,33 +152,31 @@
         new Date().toLocaleTimeString()
     )
     try {
-      const problemTitle = document.querySelector(
-        "#qd-content > div > div.flexlayout__tab > div > div > div > div > div > a"
-      )
+      // 从 URL 提取题目 slug，再从页面标题链接中提取题号
+      const problemLinks = document.querySelectorAll('a[href^="/problems/"]')
+      let problemIndex = null
+      for (const link of problemLinks) {
+        const match = (link.textContent || "").match(/^(\d+)\.\s/)
+        if (match) {
+          problemIndex = match[1]
+          break
+        }
+      }
 
-      console.log(
-        "[LeetCodeRating] problemTitle:",
-        problemTitle ? "Found" : "Not found"
-      )
-      if (problemTitle == undefined) {
+      if (problemIndex == null) {
         lastProcessedProblemId = "unknown"
         return
       }
 
-      const problemIndex = problemTitle.innerText.split(".")[0].trim()
-
-      if (
-        lastProcessedProblemId != undefined &&
-        lastProcessedProblemId == problemIndex
-      ) {
+      if (lastProcessedProblemId == problemIndex) {
         return
       }
 
       const colorSpan = document.querySelector(
-        "#qd-content > div > div.flexlayout__tab > div > div > div.flex.gap-1 > div"
+        '[class*="text-difficulty-easy"], [class*="text-difficulty-medium"], [class*="text-difficulty-hard"]'
       )
+      if (!colorSpan) return
 
-      // 新版统计难度分数并且修改
       if (t2rate[problemIndex] != undefined) {
         console.log(
           `[LeetCodeRating] Found rating for problem ${problemIndex}: ${t2rate[problemIndex].Rating}`
@@ -194,26 +186,13 @@
         console.log(
           `[LeetCodeRating] No rating found for problem ${problemIndex}, restoring original difficulty`
         )
-        // 恢复原始难度显示
-        const problemDifficulty = colorSpan.getAttribute("class")
-        const difficultyMap = {
-          "text-difficulty-easy": "Easy",
-          "text-difficulty-medium": "Medium",
-          "text-difficulty-hard": "Hard",
-        }
-
-        // 检查class中包含哪种难度
-        let originalDifficulty = "Unknown"
-        for (const diffClass in difficultyMap) {
-          if (problemDifficulty && problemDifficulty.includes(diffClass)) {
-            originalDifficulty = difficultyMap[diffClass]
-            break
-          }
-        }
-        colorSpan.innerHTML = originalDifficulty
+        const classList = colorSpan.getAttribute("class") || ""
+        if (classList.includes("text-difficulty-easy")) colorSpan.innerHTML = "Easy"
+        else if (classList.includes("text-difficulty-medium")) colorSpan.innerHTML = "Medium"
+        else if (classList.includes("text-difficulty-hard")) colorSpan.innerHTML = "Hard"
       }
 
-      lastProcessedProblemId = deepclone(problemIndex)
+      lastProcessedProblemId = problemIndex
     } catch (e) {
       return
     }

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "2.0.0",
-  "content": "Refactor the plugin, change the refresh and update logic"
+  "version": "2.0.1",
+  "content": "fix problem page rating display after LeetCode UI update; fix rating not shown on first install or daily first data fetch"
 }


### PR DESCRIPTION
## Summary

- **Fix problem page rating not displaying** — the previous selector (`#qd-content > div > ...`) broke after a LeetCode UI update. Replaced with a link-text match (`a[href^="/problems/"]` + `/^\d+\.\s/`) that is resilient to DOM structure changes.

- **Fix rating not shown on first install or daily first fetch** — after new data loaded via `GM_xmlhttpRequest`, `lastProcessedProblemId` and `data-lc-rating-processed` markers were not reset, so `tryProcess()` returned early and the current page was never re-rendered with fresh data. State is now cleared before calling `tryProcess()` inside `onload`.

- **Additional cleanup** (no behavior change):
  - Add trailing slash to `problemUrl` to eliminate URL prefix ambiguity with `/problemset`
  - Replace per-element `oncopy` loop with `document.addEventListener('copy', ..., true)` — covers dynamically rendered elements
  - Move `t2rate.tagVersion` metadata to a dedicated `GM_getValue` key (`t2rateInitialized`) to avoid mixing metadata into the data object
  - Replace `innerHTML` with `textContent` for rating/difficulty labels
  - Remove unused `deepclone`, `getCurrentDate` functions and dead code
  - Improve error logging (`console.error` in catch blocks and `onerror` handlers)

## Test plan

- [ ] Fresh install: open a problem page, verify rating shows after data loads
- [ ] Daily first open (clear `preDate` in GM storage to simulate): verify rating refreshes with new data on current page
- [ ] Navigate between problems via SPA routing: verify rating updates correctly
- [ ] Problemset page (`/problemset`): verify difficulty labels replaced with ratings
- [ ] Problem with no rating entry: verify original difficulty label restored
